### PR TITLE
Update navigation structure in mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,9 +7,9 @@ nav:
   - Home: index.md
   - User Gudes:
       - Methods:
-          - File Operations: user-guide/methods/fileop.md
-          - NIOS WAPI: user-guide/methods/wapi.md
-          - NIOS Services: user-guide/methods/service.md
+          - File Operations: user-guide/classes/fileop.md
+          - NIOS WAPI: user-guide/classes/wapi.md
+          - NIOS Services: user-guide/classes/service.md
       - Examples:
           - CSV Export: user-guide/examples/csvexport.md
           - CSV Import: user-guide/examples/csvimport.md


### PR DESCRIPTION
This commit modifies mkdocs.yml, updating the file paths under 'User Guides' from 'methods' to 'classes'. This change enhances the organization of the documentation, resulting in improved readability and accessibility for users.