### PR TITLE
Renamed 'get_config' to 'get_file' and updated docs

### DIFF
--- a/docs/user-guide/examples/get_config.md
+++ b/docs/user-guide/examples/get_config.md
@@ -1,1 +1,0 @@
-# Get Config

--- a/docs/user-guide/examples/get_file.md
+++ b/docs/user-guide/examples/get_file.md
@@ -1,0 +1,47 @@
+# Get File
+
+## Overview
+
+This Python script serves as a command-line utility for retrieving files from an Infoblox Grid Manager using the
+Infoblox Web API (WAPI). Users can specify key parameters such as the Grid Manager address, the target member from
+which to retrieve configuration data, and the type of configuration  (e.g., DNS_CFG, DHCP_CFG) when executing the
+script from the command line. Optional parameters include the Infoblox admin username, the option to exclude rotated
+logs, and the ability to enable debugging for troubleshooting purposes. Whether you need to access DNS, DHCP, or
+other file data from Infoblox, this utility simplifies the process.
+
+## Usage
+
+```
+Usage: get-file [OPTIONS]
+
+  Get NIOS File
+
+Options:
+  Required Parameters: 
+    -g, --grid-mgr TEXT  Infoblox Grid Manager  [required]
+    -m, --member TEXT    Member to retrieve file from  [required]
+  Optional Parameters: 
+    -u, --username TEXT  Infoblox admin username  [default: admin]
+    -t, --cfg-type TEXT  Configuration Type: DNS_CACHE | DNS_CFG | DHCP_CFG | DHCPV6_CFG |
+                         TRAFFIC_CAPTURE_FILE | DNS_STATS | DNS_RECURSING_CACHE  [default:
+                         DNS_CFG]
+    -w, --wapi-ver TEXT  Infoblox WAPI version  [default: 2.11]
+  Logging Parameters: 
+    --debug              enable verbose debug output
+  -h, --help             Show this message and exit.
+
+```
+
+## Examples
+
+```sh
+get-file -u admin -g 192.168.1.2 -m infoblox.localdomain -t DNS_CFG
+```
+
+```sh
+get-file -u admin -g 192.168.1.2 -m infoblox.localdomain -t DHCP_CFG
+```
+
+```sh
+get-file -u admin -g 192.168.1.2 -m infoblox.localdomain -t DHCPV6_CFG
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -123,7 +123,7 @@ nav:
       - Examples:
           - CSV Export: user-guide/examples/csvexport.md
           - CSV Import: user-guide/examples/csvimport.md
-          - Get Configuration: user-guide/examples/get_config.md
+          - Get File: user-guide/examples/get_file.md
           - Get Log: user-guide/examples/get_log.md
           - Get Support Bundle: user-guide/examples/get_supportbundle.md
           - Grid Backup: user-guide/examples/grid_backup.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
 
 [project.scripts]
 get-log = 'ibx_tools.bin.nios_get_log:main'
-get-config = 'ibx_tools.bin.nios_get_config:main'
+get-file = 'ibx_tools.bin.nios_get_file:main'
 get-supportbundle = 'ibx_tools.bin.nios_get_supportbundle:main'
 grid-backup = 'ibx_tools.bin.nios_grid_backup:main'
 grid-restore = 'ibx_tools.bin.nios_grid_restore:main'

--- a/src/ibx_tools/bin/nios_get_file.py
+++ b/src/ibx_tools/bin/nios_get_file.py
@@ -36,7 +36,7 @@ log = init_logger(
 wapi = WAPI()
 
 help_text = """
-Get NIOS Configuration from Member
+Get NIOS File from member
     
 """
 
@@ -44,12 +44,11 @@ Get NIOS Configuration from Member
 @click.command(help=help_text, context_settings=dict(max_content_width=95, help_option_names=['-h', '--help']))
 @optgroup.group("Required Parameters")
 @optgroup.option('-g', '--grid-mgr', required=True, help='Infoblox Grid Manager')
-@optgroup.option('-m', '--member', required=True, help='Member to retrieve log from')
+@optgroup.option('-m', '--member', required=True, help='Member to retrieve file from')
 @optgroup.group("Optional Parameters")
 @optgroup.option('-u', '--username', default='admin', show_default=True, help='Infoblox admin username')
 @optgroup.option('-t', '--cfg-type', default='DNS_CFG', show_default=True,
                  help='Configuration Type: DNS_CACHE | DNS_CFG | DHCP_CFG | DHCPV6_CFG | TRAFFIC_CAPTURE_FILE | DNS_STATS | DNS_RECURSING_CACHE')
-@optgroup.option('-r', '--rotated-logs', is_flag=True, default=True, help='Exclude Rotated Logs')
 @optgroup.option('-w', '--wapi-ver', default='2.11', show_default=True, help='Infoblox WAPI version')
 @optgroup.group("Logging Parameters")
 @optgroup.option('--debug', is_flag=True, help='enable verbose debug output')


### PR DESCRIPTION
The user guide, code, and other references of 'get_config' have been renamed to 'get_file'. A detailed documentation for 'get_file' has also been included in the user guide. In addition, the script command in pyproject.toml has been updated to reflect the command name change.