### PR TITLE
Mkdocs cleanup

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -135,6 +135,7 @@ nav:
       - wapi: classes/nios/gift.md
       - fileop: classes/nios/fileop.md
       - service: classes/nios/service.md
+      - logger: classes/nios/logger.md
   - Modules:
       - util: modules/util.md
       - ibx_logger: modules/logger.md

--- a/src/ibx_tools/logger/ibx_logger.py
+++ b/src/ibx_tools/logger/ibx_logger.py
@@ -17,7 +17,7 @@ limitations under the License.
 import logging
 import os
 from logging.handlers import RotatingFileHandler
-from typing import Optional
+from typing import Optional, Any
 
 import coloredlogs
 
@@ -44,7 +44,7 @@ class CallCounted:
         self.method = method
         self.counter = 0
 
-    def __call__(self, *args, **kwargs):
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
         """
         Call the decorated method and increment the call count.
 

--- a/src/ibx_tools/nios/fileop.py
+++ b/src/ibx_tools/nios/fileop.py
@@ -56,7 +56,8 @@ class NiosFileopMixin:
         Args:
             wapi_object: The name of the WAPI object to perform a CSV export on.
             filename: Optional. The name of the file to save the exported data to. If not
-            provided, a default filename will be generated based on the download URL.
+                                provided, a default filename will be generated based on the
+                                download URL.
 
         Raises:
             requests.exceptions.RequestException: If there is an error in the request.
@@ -109,11 +110,11 @@ class NiosFileopMixin:
         Perform a CSV import task using the NIOS CSV Task Manager
 
         Args:
-            task_operation: The operation to be performed on the CSV file. Should be a value from
-            the `CsvOperation` enum.
-            csv_import_file: The path to the CSV file to be imported.
-            exit_on_error: Indicates whether the program should exit if an error occurs during
-            the import process. Default value is `False`.
+            task_operation (CsvOperation): The operation to be performed on the CSV file. Should be
+                                           a value from the `CsvOperation` enum.
+            csv_import_file (str): The path to the CSV file to be imported.
+            exit_on_error (bool): Indicates whether the program should exit if an error occurs
+                                  during the import process. Default value is `False`.
 
         Returns:
             A dictionary containing the result of the CSV import task.
@@ -300,14 +301,14 @@ class NiosFileopMixin:
         Fetch the log files for the provided member or msserver
 
         Args:
-            log_type: The type of log files to fetch.
-            filename: The name of the log file to download (Default value = None)
-            endpoint: The specific endpoint for which to fetch log files. (Default: None)
-            include_rotated: Whether to include rotated log files. (Default: False)
-            member: The member for which to fetch log files. (Default: None)
-            msserver: The msserver for which to fetch log files. (Default: None)
+            log_type (LogType): The type of log files to fetch.
+            filename (str): The name of the log file to download (Default value = None)
+            endpoint (str): The specific endpoint for which to fetch log files. (Default: None)
+            include_rotated (bool): Whether to include rotated log files. (Default: False)
+            member (str): The member for which to fetch log files. (Default: None)
+            msserver (str): The msserver for which to fetch log files. (Default: None)
             node_type: The type of node for which to fetch log files. Can be 'ACTIVE' or
-            'BACKUP'. (Default: None)
+                       'BACKUP'. (Default: None)
         """
         logging.info('fetching %s log files for %s', log_type, member)
         payload = {
@@ -384,25 +385,22 @@ class NiosFileopMixin:
             member (str): The member for which to retrieve the support bundle.
             filename (str, optional): The filename of the support bundle.
             cached_zone_data (bool, optional): Whether to include cached zone data in the support
-            bundle. Defaults to False.
+                                               bundle. Defaults to False.
             core_files (bool, optional): Whether to include core files in the support bundle.
-            Defaults to False.
+                                         Defaults to False.
             log_files (bool, optional): Whether to include log files in the support bundle.
-            Defaults to False.
+                                        Defaults to False.
             nm_snmp_logs (bool, optional): Whether to include NM SNMP logs in the support bundle.
-            Defaults to False.
+                                           Defaults to False.
             recursive_cache_file (bool, optional): Whether to include recursive cache file in the
-            support bundle. Defaults to False.
+                                                   support bundle. Defaults to False.
             remote_url (str, optional): The remote URL where the support bundle will be uploaded.
-            Defaults to None.
+                                        Defaults to None.
             rotate_log_files (bool, optional): Whether to rotate log files before creating the
-            support bundle. Defaults to False.
+                                               support bundle. Defaults to False.
 
         Raises:
             requests.exceptions.RequestException: If an error occurs during the request.
-
-        Returns:
-            None.
 
         """
         logging.info('performing get_support_bundle for %s object(s)', member)
@@ -512,9 +510,8 @@ class NiosFileopMixin:
         Perform a NIOS Grid restore of a database using a given file.
 
         Args:
-            self: Reference to the current object.
             filename (str): The filename of the database file to be restored. Default is
-            "database.tgz".
+                            "database.tgz".
             mode (GridRestoreMode): The restore mode to be used. Default is "NORMAL".
             keep_grid_ip (bool): Indicates whether to keep the grid IP address. Default is False.
 

--- a/src/ibx_tools/nios/service.py
+++ b/src/ibx_tools/nios/service.py
@@ -48,9 +48,9 @@ class NiosServiceMixin:
             members (Optional[list[str]]): List of member names. Default is None.
             mode (Optional[ServiceRestartMode]): Restart mode. Default is None.
             restart_option (Optional[ServiceRestartOption]): Restart option. Default is
-            'RESTART_IF_NEEDED'.
+                            'RESTART_IF_NEEDED'.
             services (Optional[list[ServiceRestartServices]]): List of services to restart.
-            Default is None.
+                                                               Default is None.
             user_name (Optional[str]): Username. Default is None.
 
         Returns:

--- a/src/ibx_tools/util/util.py
+++ b/src/ibx_tools/util/util.py
@@ -73,11 +73,11 @@ def named_compilezone(
     Args:
         zone_name (str): The name of the DNS zone being processed.
         zone_file (str): The path to the file containing the DNS zone information to be
-        read/processed.
+                         read/processed.
         output_file (str): The path where the canonicalized zone file will be written to.
         input_format (str, optional): The format in which the zone information is currently
-        presented in the zone file.
-            This should be either 'text' or 'raw'. Defaults to 'text'.
+                                      presented in the zone file.
+                                      This should be either 'text' or 'raw'. Defaults to 'text'.
 
     Returns:
         list: A list of strings, each string being a line from the output of the named-compilezone
@@ -136,12 +136,12 @@ def remove_lines_from_file(file_path: str, lines_to_remove: list, output_path: s
 
     Args:
         file_path (str): The fully qualified path to the file from which lines are to be removed.
-        lines_to_remove (list): A list of integers, with each integer being a line number (
-        1-indexed) of the line
-            to be removed from the file.
+        lines_to_remove (list): A list of integers, with each integer being a line
+                                number (1-indexed) of the line to be removed from the file.
         output_path (str, optional): Path to the output file. If provided, the function will
-        write result to this file.
-            If not provided, the function will overwrite the original file. Defaults to None.
+                                     write result to this file.
+                                     If not provided, the function will overwrite the original
+                                     file. Defaults to None.
 
     Returns:
         None
@@ -392,8 +392,8 @@ def generate_from_includes(chroot: str, filepath: str) -> str:
     Args:
         chroot (str): The path to the chroot environment where the config file to process exists.
         filepath (str): Path to the initial config file to process. The path is relative to
-        chroot if
-            it starts with '/'.
+                        chroot if
+                            it starts with '/'.
 
     Returns:
         str: A single string containing the full contents of the config file. This includes data


### PR DESCRIPTION
**Updates**

- Updated mkdocs.yml with comments and removed functionality that was commented out end not needed
- Updated docstrings accross many methods to eliminate griffe warnings that specifically related to mkdocstrings-python.  These adjustments improved the table documentation outputted by mkdocs.
- Updated several methods added Typing (**kwargs: Any)
- Testing all example scripts without issue (including backup/restore, csvexport/import, etc)

**The building of the documentation is now clean**
```(.venv) ➜  ibx-tools git:(mkdocs-cleanup) mkdocs serve
INFO    -  Building documentation...
INFO    -  Cleaning site directory
INFO    -  Documentation built in 0.80 seconds
INFO    -  [11:38:49] Watching paths for changes: 'docs', 'mkdocs.yml'
INFO    -  [11:38:49] Serving on http://127.0.0.1:8000/ibx-tools/
```

@yeti9990 - Please review and commit if you agree with he work done.