### PR TITLE
Fix: adjusted api filtering to fix the passing of _filter in the gift…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ibx-sdk"
-version = "0.7.0"
+version = "0.7.1"
 authors = [
     "Patrick Piper <patrick@ddiguru.com>",
     "Patrick Piper <ppiper@infoblox.com>",


### PR DESCRIPTION
This pull request introduces a version bump for the `ibx-sdk` package and enhances query parameter handling in the `cloud/gift.py` module. The changes improve the normalization of paths and the handling of query parameters for API calls, ensuring better consistency and flexibility.

### Version Update:
* Updated the package version in `pyproject.toml` from `0.7.0` to `0.7.1`.

### Query Parameter Handling Enhancements:
* Modified `_normalize_path` in `cloud/gift.py` to remove query parameters when normalizing paths, ensuring only the base path is processed.
* Updated `_call` in `cloud/gift.py` to split query parameters from the path, parse them, and merge them with any existing parameters passed via `kwargs`. This ensures proper handling of query parameters and avoids duplication.
* Adjusted the docstring for `_call` to clarify that the `path` argument may include query parameters.… cloud class